### PR TITLE
Update iptables.py

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -183,6 +183,8 @@ options:
         specified, using the format first:last. If the first port is omitted,
         '0' is assumed; if the last is omitted, '65535' is assumed. If the
         first port is greater than the second one they will be swapped.
+        This is only valid if the rule also specifies one of the following
+        protocols: tcp, udp, dccp or sctp.
   to_ports:
     description:
       - "This specifies a destination port or range of ports to use: without


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added to documentation the required variable 'protocol' for variable destination_port.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iptables.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
if does not use variable 'protocol' you can see error:
iptables v1.6.0: unknown option "--destination-port"
like in https://github.com/ansible/ansible-modules-extras/issues/2100
it means need notes about obligate variable in documentation of module.
```
